### PR TITLE
add requirements.txt for pip install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4
+requests


### PR DESCRIPTION
Most of the libraries there are already in Python 2.7 standard library. https://docs.python.org/2/library/

Probably don't need to list standard libraries as required libraries.

Here's `requirements.txt` for use as

`pip install -r requirements.txt`
